### PR TITLE
Fix input position on fullscreen (IE11)

### DIFF
--- a/src/PIXI.TextInput.js
+++ b/src/PIXI.TextInput.js
@@ -316,8 +316,8 @@ class TextInput extends PIXI.Container{
 		if(!this._canvas_bounds)
 			return
 
-		this._dom_input.style.top = this._canvas_bounds.top+'px'
-		this._dom_input.style.left = this._canvas_bounds.left+'px'
+		this._dom_input.style.top = (this._canvas_bounds.top || 0)+'px'
+		this._dom_input.style.left = (this._canvas_bounds.left || 0)+'px'
 		this._dom_input.style.transform = this._pixiMatrixToCSS(this._getDOMRelativeWorldTransform())
 		this._dom_input.style.opacity = this.worldAlpha
 		this._setDOMInputVisible(this.worldVisible && this._dom_visible)


### PR DESCRIPTION
This solve an issue in IE11 in fullscreen mode, the input was not positioned correctly, and I discovered that it's on `_canvas_bounds` values. With the change it will be set to 0 and will not be `undefined` never.